### PR TITLE
Update to support RGBDS v1 (English Translation)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   # Dockerfile arguments
   RGBDS_REPOSITORY: https://github.com/gbdev/rgbds.git
-  RGBDS_VERSION: v0.4.1
+  RGBDS_VERSION: v1.0.1
   OPENPYXL_REPOSITORY: https://github.com/VariantXYZ/openpyxl-variant.git
   OPENPYXL_VERSION: 873cc3dda43578c098843ebe930325c879d20baf
   PYTHON_VERSION_NUM: 3.10.6

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sav
 *.sgm
 build/
+build.log
 /patch/
 *.sn*
 *.sna
@@ -18,3 +19,4 @@ scripts/common/__pycache__/
 
 # venv
 env/
+.venv

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ dump_tilesets: | $(TILESETS_TEXT) $(TILESET_BIN)
 	$(PYTHON) $(SCRIPT)/dump_tilesets.py
 
 clean:
-	rm -r $(BUILD) $(TARGETS) $(SYM_OUT) $(MAP_OUT) || exit 0
+	rm -rf $(BUILD) $(TARGETS) $(SYM_OUT) $(MAP_OUT) || exit 0
 
 # Rules to stop Make from deleting outputs...
 list_files:  $(LISTS_FILES)

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ TEXT := BattleText Snippet1 Snippet2 Snippet3 Snippet4 Snippet5 StoryText1 Story
 
 # Toolchain
 CC := rgbasm
-CC_ARGS := -Weverything
+CC_ARGS := -Weverything -Werror=obsolete
 LD := rgblink
-LD_ARGS :=
+LD_ARGS := -p 0xFF -Weverything -Werror=obsolete
 FIX := rgbfix
 FIX_ARGS :=
 CCGFX := rgbgfx
@@ -117,7 +117,7 @@ robattle_misc_ADDITIONAL := $(UNCOMPRESSED_TILESET_FILES)
 # Manually add MainDialog as a special case for map text reloading
 patch_ADDITIONAL :=
 patch_hack_ADDITIONAL := $(PATCH_TILESET_FILES) $(TILESET_OUT)/MainDialog.malias $(PATCH_BIN_FILES) $(PATCH_TEXT_TILESET_FILES)
-patch_vwf_ADDITIONAL := $(PATCH_TEXT_TILESET_FILES) 
+patch_vwf_ADDITIONAL := $(PATCH_TEXT_TILESET_FILES)
 patch_locations_ADDITIONAL := $(PTRLISTS_OUT)/Locations.$(SOURCE_TYPE)
 
 portraits_ADDITIONAL := $(PATCH_PORTRAIT_TILESET_FILES)
@@ -146,7 +146,7 @@ $(BASE)/$(OUTPUT_PREFIX)%.$(ROM_TYPE): $(OBJECTS) \
 	$$(addprefix $(BUILD)/$$*., $$(addsuffix .$(INT_TYPE), $$(notdir $$(basename $$(wildcard $(SRC)/$$(firstword $$(subst _, ,$$*))/*.$(SOURCE_TYPE)))))) \
 	$$(addprefix $(BUILD)/$$(lastword $$(subst _, ,$$*))., $$(addsuffix .$(INT_TYPE), $$(notdir $$(basename $$(wildcard $(SRC)/$$(lastword $$(subst _, ,$$*))/*.$(SOURCE_TYPE)))))) \
 	| $(BASE)/$(ORIGINAL_PREFIX)$$(firstword $$(subst _, ,$$*)).$(ROM_TYPE)
-	
+
 	$(LD) $(LD_ARGS) -n $(OUTPUT_PREFIX)$*.$(SYM_TYPE) -m $(OUTPUT_PREFIX)$*.$(MAP_TYPE) -O $| -o $@ $^
 	$(FIX) $(FIX_ARGS) -v -k 9C -l 0x33 -m 0x13 -p 0 -r 3 $@ -t "MEDAROT $(call TOUPPER,$(CURVERSION))"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 	* Currently relies on the rgbds overlay feature as parts are disassembled and tacked on
 * Make
 * Python 3.6 or greater, aliased to 'python3'
-* [rgbds](https://github.com/rednex/rgbds) >= v0.5.0 (v1 is recommended)
+* [rgbds v1.x](https://github.com/gbdev/rgbds)
 
 # Make
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **NOTE:** The versions marked '-portraits' introduce portraits. They help understand the flow of conversation in the games a lot better, but there may still be some lines that could use them that currently don't have them. Please report them if you find any!
 
 1. Obtain the original ROM for the Medarot 1 version you want (the md5 hashes are below)
-1. Head to the [Latest release](https://github.com/Medabots/medarot1/releases/latest) page and grab the .ips file for your preferred version
-1. Use an IPS Patching Tool like [LunarIPS](https://www.romhacking.net/utilities/240/), or online patcher like [this](https://vxyz.me/rompatcher/) to apply the IPS patch to your ROM
+2. Head to the [Latest release](https://github.com/Medabots/medarot1/releases/latest) page and grab the .ips file for your preferred version
+3. Use an IPS Patching Tool like [LunarIPS](https://www.romhacking.net/utilities/240/), or online patcher like [this](https://vxyz.me/rompatcher/) to apply the IPS patch to your ROM
 
 The '+txt.N' versions indicates the version of the translation.
 
@@ -26,14 +26,14 @@ If all you care about is playing the patch, then refer to the instructions at th
 	* Currently relies on the rgbds overlay feature as parts are disassembled and tacked on
 * Make 4.0+
 * Python 3.6 or greater, aliased to 'python3'
-* [rgbds v0.4.1+](https://github.com/rednex/rgbds)
+* [rgbds v1.x+](https://github.com/gbdev/rgbds)
 
 ## Make
 
 1. Rename the Medarot 1 KABUTO v1.1 ROM and/or Medarot 1 KUWAGATA v1.1 ROM to 'baserom_kabuto.gb' or 'baserom_kuwagata.gb' respectively and drop it in the project root
-1. Execute make (optionally pass -j), pass a specific version (kabuto or kuwagata) or 'all'
+2. Execute make (optionally pass -j), pass a specific version (kabuto or kuwagata) or 'all'
 	* The default for no arguments is 'kabuto'
-1. 'medarot_kabuto.gb' or 'medarot_kuwagata.gb' should be generated in your project root, depending on the version
+3. 'medarot_kabuto.gb' or 'medarot_kuwagata.gb' should be generated in your project root, depending on the version
 
 # Other References
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 	* Currently relies on the rgbds overlay feature as parts are disassembled and tacked on
 * Make
 * Python 3.6 or greater, aliased to 'python3'
-* [rgbds](https://github.com/rednex/rgbds)
+* [rgbds](https://github.com/rednex/rgbds) >= v0.5.0 (v1 is recommended)
 
 # Make
 

--- a/game/src/common/constants.asm
+++ b/game/src/common/constants.asm
@@ -107,8 +107,8 @@ DEF    hCGB               EQU $ffe6
 DEF    hSGB               EQU $ffe7
 DEF    hDMATransfer       EQU $ffe8
 
-hSaveA             EQU $FF90
-hBank              EQU $FF91
+DEF    hSaveA             EQU $FF90
+DEF    hBank              EQU $FF91
 
 ; Joypad
 DEF    hJPInputHeldDown   EQU $ff8c

--- a/game/src/common/constants.asm
+++ b/game/src/common/constants.asm
@@ -1,126 +1,126 @@
 INCLUDE "build/buffer_constants.asm"
 
-hRegJoyp           EQU $ff00
-hRegSB             EQU $ff01
-hRegSC             EQU $ff02
-hRegIF             EQU $ff0f
-hRegNR10           EQU $ff10
-hRegNR11           EQU $ff11
-hRegNR12           EQU $ff12
-hRegNR13           EQU $ff13
-hRegNR14           EQU $ff14
-hRegNR21           EQU $ff16
-hRegNR22           EQU $ff17
-hRegNR23           EQU $ff18
-hRegNR24           EQU $ff19
-hRegNR30           EQU $ff1a
-hRegNR31           EQU $ff1b
-hRegNR32           EQU $ff1c
-hRegNR33           EQU $ff1d
-hRegNR34           EQU $ff1e
-hRegNR41           EQU $ff20
-hRegNR42           EQU $ff21
-hRegNR43           EQU $ff22
-hRegNR44           EQU $ff23
-hRegNR50           EQU $ff24
-hRegNR51           EQU $ff25
-hRegNR52           EQU $ff26
-hRegLCDC           EQU $ff40
-hLCDStat           EQU $ff41
-hRegSCY            EQU $ff42
-hRegSCX            EQU $ff43
-hRegLY             EQU $ff44
-hRegLYC            EQU $ff45
-hRegDMA            EQU $ff46
-hRegBGP            EQU $ff47
-hRegOBP0           EQU $ff48
-hRegOBP1           EQU $ff49
-hRegWY             EQU $ff4a
-hRegWX             EQU $ff4b
-hRegKEY1           EQU $ff4d
-hRegVBK            EQU $ff4f
-hRegRP             EQU $ff56
-hRegBGPI           EQU $ff68
-hRegBGPD           EQU $ff69
-hRegOBPI           EQU $ff6a
-hRegOBPD           EQU $ff6b
-hRegSVBK           EQU $ff70
-hRegIE             EQU $ffff
+DEF    hRegJoyp           EQU $ff00
+DEF    hRegSB             EQU $ff01
+DEF    hRegSC             EQU $ff02
+DEF    hRegIF             EQU $ff0f
+DEF    hRegNR10           EQU $ff10
+DEF    hRegNR11           EQU $ff11
+DEF    hRegNR12           EQU $ff12
+DEF    hRegNR13           EQU $ff13
+DEF    hRegNR14           EQU $ff14
+DEF    hRegNR21           EQU $ff16
+DEF    hRegNR22           EQU $ff17
+DEF    hRegNR23           EQU $ff18
+DEF    hRegNR24           EQU $ff19
+DEF    hRegNR30           EQU $ff1a
+DEF    hRegNR31           EQU $ff1b
+DEF    hRegNR32           EQU $ff1c
+DEF    hRegNR33           EQU $ff1d
+DEF    hRegNR34           EQU $ff1e
+DEF    hRegNR41           EQU $ff20
+DEF    hRegNR42           EQU $ff21
+DEF    hRegNR43           EQU $ff22
+DEF    hRegNR44           EQU $ff23
+DEF    hRegNR50           EQU $ff24
+DEF    hRegNR51           EQU $ff25
+DEF    hRegNR52           EQU $ff26
+DEF    hRegLCDC           EQU $ff40
+DEF    hLCDStat           EQU $ff41
+DEF    hRegSCY            EQU $ff42
+DEF    hRegSCX            EQU $ff43
+DEF    hRegLY             EQU $ff44
+DEF    hRegLYC            EQU $ff45
+DEF    hRegDMA            EQU $ff46
+DEF    hRegBGP            EQU $ff47
+DEF    hRegOBP0           EQU $ff48
+DEF    hRegOBP1           EQU $ff49
+DEF    hRegWY             EQU $ff4a
+DEF    hRegWX             EQU $ff4b
+DEF    hRegKEY1           EQU $ff4d
+DEF    hRegVBK            EQU $ff4f
+DEF    hRegRP             EQU $ff56
+DEF    hRegBGPI           EQU $ff68
+DEF    hRegBGPD           EQU $ff69
+DEF    hRegOBPI           EQU $ff6a
+DEF    hRegOBPD           EQU $ff6b
+DEF    hRegSVBK           EQU $ff70
+DEF    hRegIE             EQU $ffff
 
-hPushOAM           EQU $ff80
+DEF    hPushOAM           EQU $ff80
 
-hBuffer            EQU $ff8b
+DEF    hBuffer            EQU $ff8b
 
-hRTCDayHi          EQU $ff8d
-hRTCDayLo          EQU $ff8e
-hRTCHours          EQU $ff8f
-hRTCMinutes        EQU $ff90
-hRTCSeconds        EQU $ff91
+DEF    hRTCDayHi          EQU $ff8d
+DEF    hRTCDayLo          EQU $ff8e
+DEF    hRTCHours          EQU $ff8f
+DEF    hRTCMinutes        EQU $ff90
+DEF    hRTCSeconds        EQU $ff91
 
-hHours             EQU $ff94
+DEF    hHours             EQU $ff94
 
-hMinutes           EQU $ff96
+DEF    hMinutes           EQU $ff96
 
-hSeconds           EQU $ff98
+DEF    hSeconds           EQU $ff98
 
-hROMBank           EQU $ff9d
+DEF    hROMBank           EQU $ff9d
 
-hJoypadReleased    EQU $ffa2
-hJoypadPressed     EQU $ffa3
-hJoypadDown        EQU $ffa4
-hJoypadSum         EQU $ffa5
-hJoyReleased       EQU $ffa6
-hJoyPressed        EQU $ffa7
-hJoyDown           EQU $ffa8
+DEF    hJoypadReleased    EQU $ffa2
+DEF    hJoypadPressed     EQU $ffa3
+DEF    hJoypadDown        EQU $ffa4
+DEF    hJoypadSum         EQU $ffa5
+DEF    hJoyReleased       EQU $ffa6
+DEF    hJoyPressed        EQU $ffa7
+DEF    hJoyDown           EQU $ffa8
 
-hPastLeadingZeroes EQU $ffb3
+DEF    hPastLeadingZeroes EQU $ffb3
 
-hDividend          EQU $ffb3
-hDivisor           EQU $ffb7
-hQuotient          EQU $ffb4
+DEF    hDividend          EQU $ffb3
+DEF    hDivisor           EQU $ffb7
+DEF    hQuotient          EQU $ffb4
 
-hMultiplicand      EQU $ffb4
-hMultiplier        EQU $ffb7
-hProduct           EQU $ffb3
+DEF    hMultiplicand      EQU $ffb4
+DEF    hMultiplier        EQU $ffb7
+DEF    hProduct           EQU $ffb3
 
-hMathBuffer        EQU $ffb8
+DEF    hMathBuffer        EQU $ffb8
 
-hLCDStatCustom     EQU $ffc6
+DEF    hLCDStatCustom     EQU $ffc6
 
-hBGMapMode         EQU $ffd4
-hBGMapThird        EQU $ffd5
-hBGMapAddress      EQU $ffd6
+DEF    hBGMapMode         EQU $ffd4
+DEF    hBGMapThird        EQU $ffd5
+DEF    hBGMapAddress      EQU $ffd6
 
-hOAMUpdate         EQU $ffd8
-hSPBuffer          EQU $ffd9
+DEF    hOAMUpdate         EQU $ffd8
+DEF    hSPBuffer          EQU $ffd9
 
-hBGMapUpdate       EQU $ffdb
+DEF    hBGMapUpdate       EQU $ffdb
 
-hTileAnimFrame     EQU $ffdf
+DEF    hTileAnimFrame     EQU $ffdf
 
-hRandomAdd         EQU $ffe1
-hRandomSub         EQU $ffe2
+DEF    hRandomAdd         EQU $ffe1
+DEF    hRandomSub         EQU $ffe2
 
-hBattleTurn        EQU $ffe4
-hCGBPalUpdate      EQU $ffe5
-hCGB               EQU $ffe6
-hSGB               EQU $ffe7
-hDMATransfer       EQU $ffe8
+DEF    hBattleTurn        EQU $ffe4
+DEF    hCGBPalUpdate      EQU $ffe5
+DEF    hCGB               EQU $ffe6
+DEF    hSGB               EQU $ffe7
+DEF    hDMATransfer       EQU $ffe8
 
 ; Joypad
-hJPInputHeldDown   EQU $ff8c
-hJPInputChanged    EQU $ff8d
+DEF    hJPInputHeldDown   EQU $ff8c
+DEF    hJPInputChanged    EQU $ff8d
 
-hJPInputA          EQU $1
-hJPInputB          EQU $2
-hJPInputSelect     EQU $4
-hJPInputStart      EQU $8
-hJPInputRight      EQU $10
-hJPInputLeft       EQU $20
-hJPInputUp         EQU $40
-hJPInputDown       EQU $80
+DEF    hJPInputA          EQU $1
+DEF    hJPInputB          EQU $2
+DEF    hJPInputSelect     EQU $4
+DEF    hJPInputStart      EQU $8
+DEF    hJPInputRight      EQU $10
+DEF    hJPInputLeft       EQU $20
+DEF    hJPInputUp         EQU $40
+DEF    hJPInputDown       EQU $80
 
 ; For SGB Tilemaps.
-P4 EQU $1000
-P5 EQU $1400
-P6 EQU $1800
+DEF    P4 EQU $1000
+DEF    P5 EQU $1400
+DEF    P6 EQU $1800

--- a/game/src/common/macros.asm
+++ b/game/src/common/macros.asm
@@ -1,22 +1,22 @@
 ; macro for putting a byte then a word
-dbw: MACRO
+MACRO dbw
   db \1
   dw \2
   ENDM
 
 ; macro for putting a word then a byte
-dwb: MACRO
+MACRO dwb
   dw \1
   db \2
   ENDM
 
-dbww: MACRO
+MACRO dbww
   db \1
   dw \2
   dw \3
   ENDM
   
-atfline: MACRO
+MACRO atfline
   db ((((\1 % 10000) / 1000) % 4) << 6) + ((((\1 % 1000) / 100) % 4) << 4) + ((((\1 % 100) / 10) % 4) << 2) + ((\1 % 10) % 4)
   db ((((\2 % 10000) / 1000) % 4) << 6) + ((((\2 % 1000) / 100) % 4) << 4) + ((((\2 % 100) / 10) % 4) << 2) + ((\2 % 10) % 4)
   db ((((\3 % 10000) / 1000) % 4) << 6) + ((((\3 % 1000) / 100) % 4) << 4) + ((((\3 % 100) / 10) % 4) << 2) + ((\3 % 10) % 4)

--- a/game/src/common/macros.asm
+++ b/game/src/common/macros.asm
@@ -16,19 +16,19 @@ MACRO dbww
   dw \3
   ENDM
 
-psbc: MACRO
+MACRO psbc
   ld bc, (((\2&$FF)*$100)+((((\1-$20)>>1)&$F0)+((\1-1)&$F)))
   ENDM
 
-pshl: MACRO
+MACRO pshl
   ld hl, (((\2&$FF)*$100)+((((\1-$20)>>1)&$F0)+((\1-1)&$F)))
   ENDM
 
-psa: MACRO
+MACRO psa
   ld a, ((((\1-$20)>>1)&$F0)+((\1-1)&$F))
   ENDM
 
-psc: MACRO
+MACRO psc
   ld c, ((((\1-$20)>>1)&$F0)+((\1-1)&$F))
   ENDM
   
@@ -40,14 +40,14 @@ MACRO atfline
   db ((((\5 % 10000) / 1000) % 4) << 6) + ((((\5 % 1000) / 100) % 4) << 4) + ((((\5 % 100) / 10) % 4) << 2) + ((\5 % 10) % 4)
   ENDM
 
-Load1BPPTilesetLocal: MACRO
+MACRO Load1BPPTilesetLocal
   ld hl, \1
   ld de, \2
   ld b, (\3 - \2) / $8
   call Load1BPPTiles
   ENDM
 
-Load1BPPTileset: MACRO
+MACRO Load1BPPTileset
   ld hl, \1
   ld de, \2
   ld b, (\3 - \2) / $8

--- a/game/src/core/hardware.asm
+++ b/game/src/core/hardware.asm
@@ -19,7 +19,7 @@ SECTION "WaitLCDController", ROM0[$17cb]
 WaitLCDController:: ; 17cb (0:17cb)
   push af
 .asm_17cc
-  ld a, [hLCDStat]
+  ldh a, [hLCDStat]
   and $02
   jr nz, .asm_17cc
   pop af

--- a/game/src/core/misc.asm
+++ b/game/src/core/misc.asm
@@ -1222,6 +1222,6 @@ Func_61af: ; 61af (1:61af)
   ld [$c74e], a
   ld [$c893], a
   ld a, $1c
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp $6732
 ; 0x61d7

--- a/game/src/core/rst.asm
+++ b/game/src/core/rst.asm
@@ -15,7 +15,7 @@ SECTION "rst8",ROM0[$8] ; HackPredef
 
 SECTION "rst8Cont",ROM0[$62] ;Replaces a bunch of empty space
 Rst8Cont:
-  ld a, [hBank]
+  ldh a, [hBank]
   push af
   ld a, BANK(HackPredef)
   rst $10
@@ -28,7 +28,7 @@ Rst8Cont:
   ret
 
 SECTION "rst10, bank swap",ROM0[$10]
-  ld [hBank], a
+  ldh [hBank], a
   ld [$2000], a
   ret
 

--- a/game/src/core/vblank_irq.asm
+++ b/game/src/core/vblank_irq.asm
@@ -62,11 +62,11 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
   ld hl, $1
   add hl, de
   ld a, [hl]
-  ld [hRegSCX], a
+  ldh [hRegSCX], a
   ld hl, $2
   add hl, de
   ld a, [hl]
-  ld [hRegSCY], a
+  ldh [hRegSCY], a
   ld hl, $0
   add hl, de
   ld a, [hl]
@@ -83,8 +83,8 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
 ; 0x517
 .asm_517: ; 517 (0:517)
   xor a
-  ld [hRegSCX], a
-  ld [hRegSCY], a
+  ldh [hRegSCX], a
+  ldh [hRegSCY], a
   jp .asm_549
 .asm_51f: ; 51f (0:51f)
   xor a
@@ -93,14 +93,14 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
   ld hl, $c800
 .asm_529
   ld a, [hli]
-  ld [hRegSCX], a
+  ldh [hRegSCX], a
   ld a, $00
-  ld [hRegSCY], a
+  ldh [hRegSCY], a
   ld a, [$c7fc]
   ld b, a
 .asm_534
   call WaitLCDController
-  ld a, [hRegLY]
+  ldh a, [hRegLY]
   sub b
   jr c, .asm_534
   ld a, [$c7fc]

--- a/game/src/core/vblank_irq.asm
+++ b/game/src/core/vblank_irq.asm
@@ -72,7 +72,7 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
   ld a, [hl]
   ld b, a
 .asm_509
-  ld a, [hRegLY]
+  ldh a, [hRegLY]
   sub b
   jr c, .asm_509
   ld hl, $3

--- a/game/src/core/vblank_irq.asm
+++ b/game/src/core/vblank_irq.asm
@@ -64,7 +64,7 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
   ld a, $8F ; When the original start point is 0, we can set the interrupt to occur at $8F, leaving 1 more than the vblank period to draw
   ld [HackHBlankOriginal], a
 .hack_notzero
-  ld [hRegLYC], a
+  ldh [hRegLYC], a
   ld a, $b0
   ld [HackHBlankOffset], a
   ld de, -$03
@@ -84,17 +84,17 @@ LCDC_Status_IRQ: ; 4d0 (0:4d0)
   ld a, [$c5aa] ; if c5aa is set, use that instead as the original point
   or a
   jr nz, .use_c5aa
-  ld a, [hRegLYC] ; If c5aa isn't set, take the value of ff45
+  ldh a, [hRegLYC] ; If c5aa isn't set, take the value of ff45
 .use_c5aa
   ld [HackHBlankOriginal], a
 .draw_scroll_section_not_original
   ; Starting at c6b0, there are sets of 3 bytes indicating which line to apply the scroll until, SCX, SCY
   ld a, [hli] ; [0] = Line to stop at
-  ld [hRegLYC], a
+  ldh [hRegLYC], a
   ld a, [hli]
-  ld [hRegSCX], a ; [1] = SCX
+  ldh [hRegSCX], a ; [1] = SCX
   ld a, [hli]
-  ld [hRegSCY], a ; [2] = SCY
+  ldh [hRegSCY], a ; [2] = SCY
   ld a, l
   ld [HackHBlankOffset], a
   jr .draw_scroll_return
@@ -177,7 +177,7 @@ ResetIRQVars::
   ret
 HBlankWaitForLine::
 .waitforline
-  ld a, [hRegLY]
+  ldh a, [hRegLY]
   cp b
   jr c, .waitforline
   ret

--- a/game/src/gfx/sgb.asm
+++ b/game/src/gfx/sgb.asm
@@ -158,9 +158,9 @@ SGB_SendPackets::
     push bc
 
     ld a, 0
-    ld [c], a
+    ldh [c], a
     ld a, $30
-    ld [c], a
+    ldh [c], a
 
     ld b, $10
 
@@ -179,10 +179,10 @@ SGB_SendPackets::
     ld a, $20
 
 .sendOneBit
-    ld [c], a
+    ldh [c], a
 
     ld a, $30
-    ld [c], a
+    ldh [c], a
 
     rr d
     dec e
@@ -192,9 +192,9 @@ SGB_SendPackets::
     jr nz, .beginByte
 
     ld a, $20
-    ld [c], a
+    ldh [c], a
     ld a, $30
-    ld [c], a
+    ldh [c], a
 
     pop bc
     dec b

--- a/game/src/link/core.asm
+++ b/game/src/link/core.asm
@@ -103,7 +103,7 @@ LinkMenuStateMachineDrawSavingTileset: ; 1c185 (7:4185)
   or a
   jp nz, .selected_no
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $01
   call JumpSetupDialog
   call $535d
@@ -157,7 +157,7 @@ LinkMenuStateMachineLoadMainTilemap:: ; 1c272 (7:4272)
   ld a, $02
   call JumpTable_309
   ld a, $05
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $08
   call JumpTable_17d
   jp JumpIncSubStateIndexWrapper
@@ -178,20 +178,20 @@ LinkMenuStateMachineMainMenuSteadyState:: ; 1c2c0 (7:42c0)
   xor a
   ld [$c740], a
   ld a, $04
-  ld [$ffa1], a
+  ldh [$ffa1], a
   jp JumpIncSubStateIndexWrapper
 .asm_1c2e2
   ld a, [$c6f0]
   ld b, a
   ld a, $00
   call LinkMenuLoadSelectorTilemap
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputA | hJPInputStart
   jp nz, $4301
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputUp
   jp nz, $431e
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputDown
   jp nz, $4338
   ret

--- a/game/src/link/robattles.asm
+++ b/game/src/link/robattles.asm
@@ -133,7 +133,7 @@ LinkRobattleStateInitialize:
   ld [$c750], a
   ld [$da42], a
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp JumpIncSubStateIndexWrapper
 
 LinkRobattleSubStateDoSomething: ; not sure what this does exaclty
@@ -146,7 +146,7 @@ LinkRobattleSubStateDoSomething: ; not sure what this does exaclty
   ld a, $08
   ld [$c72d], a
   ld a, $21
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp JumpIncSubStateIndexWrapper
 
 LinkRobattleSubStateInitialize:
@@ -896,7 +896,7 @@ LinkPostRobattleLoadPartNameForRoulette: ; 1d8b3 (7:58b3)
 SECTION "Post-Robattle Screen - Partial Disassembly 3", ROMX[$4cd2], BANK[$7]
 Func_1ccd2: ; 1ccd2 (7:4cd2)
   ld a, $19
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, [$c78c]
   call JumpTable_38d
   ld a, [$c78c]

--- a/game/src/menu/core.asm
+++ b/game/src/menu/core.asm
@@ -135,7 +135,7 @@ MenuIncrementStateCounter::
 MenuWaitLCD:: ; 85a8 (2:45a8)
   push af
 .loop
-  ld a, [hLCDStat]
+  ldh a, [hLCDStat]
   and $02
   jr nz, .loop
   pop af

--- a/game/src/menu/include/variables.asm
+++ b/game/src/menu/include/variables.asm
@@ -1,11 +1,11 @@
 ; Keep variables in here as constants even though we could map the WRAM section directly
 ; Makes it easier to name things for reference without worrying about conflicts, but it does make debugging a bit harder
 
-MenuStateCounter   EQU $c6c7
-MenuStateIndex     EQU $c6c8
-MenuStateSubIndex  EQU $c6c9
+DEF    MenuStateCounter   EQU $c6c7
+DEF    MenuStateIndex     EQU $c6c8
+DEF    MenuStateSubIndex  EQU $c6c9
 
-MainMenuPosition   EQU $c6f0
-InfoMenuPosition   EQU $c6f1
+DEF    MainMenuPosition   EQU $c6f0
+DEF    InfoMenuPosition   EQU $c6f1
 
-TempStateIndex   EQU $c750 ; Used for various asynchronous operations (e.g. for exiting the menu)
+DEF    TempStateIndex   EQU $c750 ; Used for various asynchronous operations (e.g. for exiting the menu)

--- a/game/src/menu/info_menu.asm
+++ b/game/src/menu/info_menu.asm
@@ -64,19 +64,19 @@ SteadyStateInfoMenu: ; 8205 (2:4205)
   ld b, $0d
   ld c, $05
   call MenuSwapCursor
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputB
   jr z, .check_inputs
   ld a, $06
-  ld [$ffa1], a
+  ldh [$ffa1], a
   call MenuIncrementStateSubIndex
   jp MenuIncrementStateSubIndex
 .check_inputs
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputA | hJPInputStart
   jp z, .no_input
   ld a, $04
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld a, [InfoMenuPosition]
   cp $00
   jr nz, .check_medals
@@ -87,7 +87,7 @@ SteadyStateInfoMenu: ; 8205 (2:4205)
   ld c, $05
   call MenuSwapCursor
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $04
   ld [MenuStateIndex], a
   ld a, $00
@@ -103,7 +103,7 @@ SteadyStateInfoMenu: ; 8205 (2:4205)
   ld c, $05
   call MenuSwapCursor
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $05
   ld [MenuStateIndex], a
   ld a, $00
@@ -119,7 +119,7 @@ SteadyStateInfoMenu: ; 8205 (2:4205)
   ld c, $05
   call MenuSwapCursor
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $06
   ld [MenuStateIndex], a
   ld a, $00

--- a/game/src/menu/main_menu.asm
+++ b/game/src/menu/main_menu.asm
@@ -55,5 +55,5 @@ AdditionalSetupMainMenu: ; 80a4 (2:40a4)
   call JumpTable_204
   call DrawPlayerMoneyInMenu
   ld a, $05
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp MenuIncrementStateSubIndex

--- a/game/src/menu/medal_screen.asm
+++ b/game/src/menu/medal_screen.asm
@@ -164,7 +164,7 @@ MedalScreenSetupMedalTilesetStateMachineLoadMedalTileset: ; 949a (2:549a)
   xor a
   ld [TempStateIndex], a
   ld a, $06
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp MenuIncrementStateSubIndex
 
 SECTION "Medal Screen State Machine (partial disassembly)", ROMX[$54ab], BANK[$2]

--- a/game/src/menu/medarot_screen.asm
+++ b/game/src/menu/medarot_screen.asm
@@ -105,7 +105,7 @@ MedarotScreenSetupSetupMedarots: ; a968 (2:6968)
   ret z
   jp MenuIncrementStateSubIndex
 
-MedarotSelectStateIndex   EQU $c740
+DEF    MedarotSelectStateIndex   EQU $c740
 SECTION "Medarot Screen State Machine - Setup Medarot Select", ROMX[$7815], BANK[$2]
 MedarotScreenSetupMedarotSelect::
   xor a

--- a/game/src/menu/menu_exit.asm
+++ b/game/src/menu/menu_exit.asm
@@ -13,7 +13,7 @@ MenuExitAsyncRestoreTileset:: ; 975f (2:575f)
   jp MenuIncrementStateSubIndex
 MenuExitSetState:: ; 976e (2:576e)
   ld a, $05
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $01
   ld [$c600], a
   ld a, $01

--- a/game/src/patch/hack.asm
+++ b/game/src/patch/hack.asm
@@ -80,10 +80,10 @@ ZeroTextOffset:
   ld [FlagNewLine], a
   ret
 
-hLineMax           EQU $11 ;Max offset from start of line
-hLineOffset        EQU $20 ;Bytes between line tiles
-hLineCount         EQU $04 ;Total number of lines
-hLineVRAMStart     EQU $9C00 ;Initial Tile VRAM location
+DEF    hLineMax           EQU $11 ;Max offset from start of line
+DEF    hLineOffset        EQU $20 ;Bytes between line tiles
+DEF    hLineCount         EQU $04 ;Total number of lines
+DEF    hLineVRAMStart     EQU $9C00 ;Initial Tile VRAM location
 
 SetInitialName: ; TODO: In the future, we might be able to just set this as a loop and pull it from a build obj for different language support
   ld a, $87 ; H

--- a/game/src/patch/vwf.asm
+++ b/game/src/patch/vwf.asm
@@ -305,13 +305,13 @@ VWFRoboticBoldFont::
 VWFMessageBoxInputHandler::
   ; Advance on button press.
 
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputA | hJPInputB
   ret nz
 
   ; Auto-advance if button held down.
 
-  ld a, [hJPInputHeldDown]
+  ldh a, [hJPInputHeldDown]
   and hJPInputA | hJPInputB
   ret z
 
@@ -927,7 +927,7 @@ VWFChar4F::
   ; No idea what this does.
 
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
 
   ; Clearing some basic variables.
 
@@ -983,7 +983,7 @@ VWFChar4F::
   ; No idea what this does.
 
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
 
   ; Clearing some basic variables.
 
@@ -1011,7 +1011,7 @@ VWFChar4F::
   ; No idea what this does.
 
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
 
   ; Or this.
 
@@ -1101,7 +1101,7 @@ VWFChar4C::
   ; No idea what this does.
 
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
 
   ; Reset auto-advance timer.
 

--- a/game/src/robattle/core.asm
+++ b/game/src/robattle/core.asm
@@ -77,7 +77,7 @@ RobattleStateInitialize: ; 1008b (4:408b)
   xor a
   ld [$c750], a
   ld a, $02
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp JumpIncSubStateIndexWrapper
 
 RobattleSubStateDoSomething: ; 1009b (4:409b), not sure what this does exaclty
@@ -90,7 +90,7 @@ RobattleSubStateDoSomething: ; 1009b (4:409b), not sure what this does exaclty
   ld a, $08
   ld [$c72d], a
   ld a, $21
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jp JumpIncSubStateIndexWrapper
 
 RobattleInitializeSubState: ; 100b5 (4:40b5)

--- a/game/src/robattle/robattles.asm
+++ b/game/src/robattle/robattles.asm
@@ -710,7 +710,7 @@ RobattleEndScreenEXP:
   ld [$c64e], a
   ret
   ld a, $19
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, [$a044]
   ld h, a
   ld a, [$a045]

--- a/game/src/shop/core.asm
+++ b/game/src/shop/core.asm
@@ -107,7 +107,7 @@ ShopBuyPriceDisplayState::
   cp b
   ret nc
   ld a, $3
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld a, [$c890]
   inc a
   ld [$c890], a
@@ -120,7 +120,7 @@ ShopBuyPriceDisplayState::
   cp $1
   ret z
   ld a, $3
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld a, [$c890]
   dec a
   ld [$c890], a
@@ -130,7 +130,7 @@ ShopBuyPriceDisplayState::
   and hJPInputB
   jr z, .bNotPressed
   ld a, $6
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld a, $c
   ld [$c7f2], a
   ld a, [$c88b]
@@ -152,7 +152,7 @@ ShopBuyPriceDisplayState::
   cp l
   jp c, $7337
   ld a, $4
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld b, $e
   ld c, $7
   ld e, $68

--- a/game/src/sound/core.asm
+++ b/game/src/sound/core.asm
@@ -6,22 +6,22 @@ PlaySound:: ; 18000 (6:4000)
   push bc
   push de
   push hl
-  ld a, [$ffa0] ; Swap music if not 0
+  ldh a, [$ffa0] ; Swap music if not 0
   cp $01
   jp z, $44b8
   or a
   jr z, .continue_same_music
   call SwapMusic
   xor a
-  ld [$ffa0], a
+  ldh [$ffa0], a
   jr .asm_18021
 .continue_same_music
-  ld a, [$ffa1] ; Sound effect
+  ldh a, [$ffa1] ; Sound effect
   or a
   jr z, .asm_18021
   call $4ae7
   xor a
-  ld [$ffa1], a
+  ldh [$ffa1], a
 .asm_18021
   ld a, [$ce90]
   or a
@@ -32,14 +32,14 @@ PlaySound:: ; 18000 (6:4000)
   ld a, $ff
   ld [$ce91], a
   ld a, $08
-  ld [hRegNR22], a
-  ld [hRegNR42], a
+  ldh [hRegNR22], a
+  ldh [hRegNR42], a
   xor a
-  ld [hRegNR32], a
+  ldh [hRegNR32], a
   ld a, $80
-  ld [hRegNR24], a
-  ld [hRegNR44], a
-  ld [hRegNR34], a
+  ldh [hRegNR24], a
+  ldh [hRegNR44], a
+  ldh [hRegNR34], a
   jp .asm_18168
 .asm_18047
   ld a, [$ce91]
@@ -48,12 +48,12 @@ PlaySound:: ; 18000 (6:4000)
   xor a
   ld [$ce91], a
   ld a, $8f
-  ld [hRegNR52], a
+  ldh [hRegNR52], a
   ld [$ce94], a
   ld a, $08
-  ld [hRegNR12], a
+  ldh [hRegNR12], a
   ld a, $80
-  ld [hRegNR14], a
+  ldh [hRegNR14], a
   xor a
   ld [$cda0], a
 .asm_18064
@@ -71,38 +71,38 @@ PlaySound:: ; 18000 (6:4000)
   sub $22
   jr c, .asm_1808a
   ld [$ce98], a
-  ld [hRegNR50], a
+  ldh [hRegNR50], a
   ld a, [$ce96]
   ld [$ce97], a
   jr .asm_180cc
 .asm_1808a
   xor a
-  ld [hRegNR50], a
+  ldh [hRegNR50], a
   ld [$ce96], a
   ld [$ce97], a
-  ld [hRegNR51], a
+  ldh [hRegNR51], a
   ld [$cd00], a
   ld [$cd28], a
   ld [$cd50], a
   ld [$cd78], a
   ld [$cda0], a
   ld [$cdc8], a
-  ld [hRegNR11], a
-  ld [hRegNR21], a
-  ld [hRegNR32], a
-  ld [hRegNR42], a
-  ld [hRegNR13], a
-  ld [hRegNR23], a
-  ld [hRegNR33], a
-  ld [hRegNR43], a
-  ld [hRegNR30], a
+  ldh [hRegNR11], a
+  ldh [hRegNR21], a
+  ldh [hRegNR32], a
+  ldh [hRegNR42], a
+  ldh [hRegNR13], a
+  ldh [hRegNR23], a
+  ldh [hRegNR33], a
+  ldh [hRegNR43], a
+  ldh [hRegNR30], a
   ld a, $08
-  ld [hRegNR10], a
+  ldh [hRegNR10], a
   ld a, $c0
-  ld [hRegNR14], a
-  ld [hRegNR24], a
-  ld [hRegNR34], a
-  ld [hRegNR44], a
+  ldh [hRegNR14], a
+  ldh [hRegNR24], a
+  ldh [hRegNR34], a
+  ldh [hRegNR44], a
   pop hl
   pop de
   pop bc
@@ -114,7 +114,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_1811d
   xor a
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_180e1
   ld a, [hl]
@@ -130,19 +130,19 @@ PlaySound:: ; 18000 (6:4000)
   ld hl, $5
   add hl, de
   ld a, [hli]
-  ld [hRegNR10], a
+  ldh [hRegNR10], a
   ld a, [hli]
-  ld [hRegNR11], a
+  ldh [hRegNR11], a
   inc hl
   ld a, [hli]
   or $08
-  ld [hRegNR12], a
+  ldh [hRegNR12], a
   inc hl
   ld a, [hli]
-  ld [hRegNR13], a
+  ldh [hRegNR13], a
   ld a, [hl]
   or $80
-  ld [hRegNR14], a
+  ldh [hRegNR14], a
   ld hl, $25
   add hl, de
   ld a, [hl]
@@ -166,7 +166,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_18136
   ld a, $01
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_18133
   ld a, [hl]
@@ -181,7 +181,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_1814f
   ld a, $02
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_1814c
   ld a, [hl]
@@ -196,7 +196,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_18168
   ld a, $03
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_18165
   ld a, [hl]
@@ -211,7 +211,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_18181
   ld a, $04
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_1817e
   ld a, [hl]
@@ -229,7 +229,7 @@ PlaySound:: ; 18000 (6:4000)
   or a
   jr z, .asm_181a0
   ld a, $05
-  ld [hJoypadReleased], a
+  ldh [hJoypadReleased], a
   call $41a5
   jr z, .asm_1819d
   ld a, [hl]
@@ -257,25 +257,25 @@ SwapMusic: ; 18aca (6:4aca)
   ld [$ceb4], a
   ld [$ceb5], a
   ld hl, $4c22
-  ld a, [$ffa0]
+  ldh a, [$ffa0]
   jr .asm_18b0d
   ld hl, $70e5
-  ld a, [$ffa1]
+  ldh a, [$ffa1]
   jr .asm_18b0d
 .asm_18aee
   inc bc
   inc bc
 .loop
-  ld a, [$ffa2]
+  ldh a, [$ffa2]
   inc a
-  ld [$ffa2], a
+  ldh [$ffa2], a
   cp $06
   jr nz, .asm_18b05
   ld a, $77
   ld [$ce98], a
-  ld [$ff24], a
+  ldh [$ff24], a
   ld a, $ff
-  ld [$ff25], a
+  ldh [$ff25], a
   ret
 .asm_18b05
   ld hl, $28
@@ -300,7 +300,7 @@ SwapMusic: ; 18aca (6:4aca)
   inc bc
   ld de, $cd00
   xor a
-  ld [$ffa2], a
+  ldh [$ffa2], a
 .asm_18b26
   ld a, [$ce92]
   add a
@@ -327,23 +327,23 @@ SwapMusic: ; 18aca (6:4aca)
   add hl, de
   ld [hl], $ff
   call $471e
-  ld a, [$ffa2]
+  ldh a, [$ffa2]
   cp $05
   jr nz, .asm_18b6d
   ld a, [$cd78]
   or a
   jp nz, $4baa
   xor a
-  ld [$ff20], a
-  ld [$ff21], a
-  ld [$ff22], a
+  ldh [$ff20], a
+  ldh [$ff21], a
+  ldh [$ff22], a
   ld a, $80
-  ld [$ff23], a
+  ldh [$ff23], a
   jp $4baa
 .asm_18b6d
   push bc
   ld hl, $4bc2
-  ld a, [$ffa2]
+  ldh a, [$ffa2]
   or a
   jr z, .asm_18b93
   ld b, $00

--- a/game/src/story/buffers.asm
+++ b/game/src/story/buffers.asm
@@ -47,12 +47,12 @@ ClearBuf: ; 4efc
 SECTION "Save name screen to buf", ROMX[$5058], BANK[$1]
 NameScreenSaveToBuf: ; 5058
   ld a, $5
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld a, [$c222]
-  ld [$ff8f], a
+  ldh [$ff8f], a
   ld a, [$c223]
   add $4
-  ld [$ff8e], a
+  ldh [$ff8e], a
   call JumpTable_1b3
   di
   call JumpWaitLCDController

--- a/game/src/story/control_codes.asm
+++ b/game/src/story/control_codes.asm
@@ -4,10 +4,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   or a
   jp nz, .Char4fMore
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1d8b ; 0x1d75 $14
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89 ; 0x1d7b $c
   ld a, [$c6c5]
@@ -20,7 +20,7 @@ Char4F:: ; 1d6b end of text
   ret
 .asm_1d8b
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c5c7], a
   ld [$c6c5], a
@@ -46,10 +46,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   cp $2
   jr nz, .asm_1de4 ; 0x1db9 $29
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1dd5 ; 0x1dbf $14
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89 ; 0x1dc5 $c2
   ld a, [$c6c5]
@@ -61,7 +61,7 @@ Char4F:: ; 1d6b end of text
   ret
 .asm_1dd5
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c6c5], a
   ld a, $1
@@ -72,10 +72,10 @@ Char4F:: ; 1d6b end of text
   ld a, [hl]
   cp $3
   jr nz, .asm_1e1b ; 0x1de7 $32
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1e03 ; 0x1ded $14
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   jr z, .asm_1d89 ; 0x1df3 $94
   ld a, [$c6c5]
@@ -87,7 +87,7 @@ Char4F:: ; 1d6b end of text
   ret
 .asm_1e03
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   ld b, $1
   ld c, $1
   ld e, $2f
@@ -155,10 +155,10 @@ Char4C:: ; 0x1e62
   call WaitLCDController
   ld [hl], a
   ei
-  ld a, [$ff8d]
+  ldh a, [$ff8d]
   and $3
   jr nz, .asm_1e94 ; 0x1e80 $12
-  ld a, [$ff8c]
+  ldh a, [$ff8c]
   and $3
   ret z
   ld a, [$c6c5]
@@ -169,7 +169,7 @@ Char4C:: ; 0x1e62
   ret
 .asm_1e94
   ld a, $22
-  ld [$ffa1], a
+  ldh [$ffa1], a
   xor a
   ld [$c6c5], a
   ld b, $1

--- a/game/src/story/misc.asm
+++ b/game/src/story/misc.asm
@@ -79,12 +79,12 @@ FortuneSpinnerUnload: ; f9fd (3:79fd), restores textbox
   jp $659c
 ; fa26
 
-FortuneGreatLuck EQU $00
-FortuneGoodLuck EQU $01
-FortuneSomeLuck EQU $02
-FortuneUncertain EQU $03
-FortuneBadLuck EQU $04
-FortuneDisaster EQU $05
+DEF   FortuneGreatLuck EQU $00
+DEF   FortuneGoodLuck EQU $01
+DEF   FortuneSomeLuck EQU $02
+DEF   FortuneUncertain EQU $03
+DEF   FortuneBadLuck EQU $04
+DEF   FortuneDisaster EQU $05
 SECTION "Fortune Spinner Disassembly 3", ROMX[$7ab6], BANK[$3]
 FortuneSpinnerLoadFortuneText: ; fab6 (3:7ab6)
   ld e, a

--- a/game/src/story/misc.asm
+++ b/game/src/story/misc.asm
@@ -60,7 +60,7 @@ FortuneSpinnerSlowingDown: ; f9f4 (3:79f4)
   call FortuneSpinnerLoadFortuneText
   jp $659c
 FortuneSpinnerUnload: ; f9fd (3:79fd), restores textbox
-  ld a, [hJPInputChanged]
+  ldh a, [hJPInputChanged]
   and hJPInputA
   ret z
   ld a, $01

--- a/game/src/story/names.asm
+++ b/game/src/story/names.asm
@@ -59,7 +59,7 @@ SetupInitialNameScreen: ;4a9f
   call JumpPutString
   call $5213
   ld a, $1
-  ld [$ffa0], a
+  ldh [$ffa0], a
   ld a, $4
   call JumpTable_17d
   ld b, $5

--- a/game/src/story/write_text.asm
+++ b/game/src/story/write_text.asm
@@ -158,12 +158,12 @@ WriteChar: ; 1f96
   jp $1d11
   ; 0x1ff2
 
-hPSTextAddrHi          EQU $c640
-hPSTextAddrLo          EQU $c641
-hPSVRAMAddrHi          EQU $c642
-hPSVRAMAddrLo          EQU $c643
-hPSCurrChar            EQU $c64e
-hPSCurrCharTile        EQU $c64f
+DEF    hPSTextAddrHi          EQU $c640
+DEF    hPSTextAddrLo          EQU $c641
+DEF    hPSVRAMAddrHi          EQU $c642
+DEF    hPSVRAMAddrLo          EQU $c643
+DEF    hPSCurrChar            EQU $c64e
+DEF    hPSCurrCharTile        EQU $c64f
 SECTION "PutString", ROM0[$2fcf]
 PutString:: ; 2fcf
   ld a, h

--- a/scripts/ptrs2asm.py
+++ b/scripts/ptrs2asm.py
@@ -10,4 +10,4 @@ if __name__ == '__main__':
     with open(output_file, 'w') as f:
     	t = utils.read_table(input_file, keystring=True)
     	for k in t:
-    		f.write("c{:<5}           EQU ${:04X}\n".format(k, int(t[k],16)))
+    		f.write("DEF    c{:<5}           EQU ${:04X}\n".format(k, int(t[k],16)))


### PR DESCRIPTION
RGBDS has seen a number of updates since 0.4.1 (the base used currently for Medarot 1).

This PR attempts to resolve breaking changes introduced by RGBDS as listed [here](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5) in order to allow the project to build using the latest version.

Specific Changes:

- [Macro definition updates](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Defining_macros_like_labels)
- Remove reliance on [`rgbasm` auto optimization of `ld`](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Automatic_LD_to_LDH_conversion_(rgbasm_-l))
- Update [constant and variable definitions](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#Defining_constants_and_variables_without_DEF)
- Optimize [`ld [c], a` calls](https://rgbds.gbdev.io/docs/v1.0.1/rgbasm-old.5#LD__C_,_A_and_LD_A,__C_)

Note: Docker workflow action was updated in this PR to prevent build failures on merge.